### PR TITLE
CYB-496 patched eosio.cdt deb-package builder

### DIFF
--- a/cicd/Dockerfile.ubuntu.patched-cdt
+++ b/cicd/Dockerfile.ubuntu.patched-cdt
@@ -1,0 +1,46 @@
+FROM ubuntu:18.04 AS cdt-patched
+
+# command-line arguments
+ARG nproc=2
+
+# other variables
+ARG cdt_threads_patch=eosio.cdt-allow-set-make-threads.patch
+ARG cdt_linker_patch=fix-linker.patch
+
+WORKDIR /
+COPY cicd/${cdt_threads_patch} /${cdt_threads_patch}
+ADD https://patch-diff.githubusercontent.com/raw/EOSIO/lld/pull/7.patch /${cdt_linker_patch}
+RUN \
+  echo ">>> Installing dependencies ..." && \
+  apt-get update && \
+  apt-get -V -y --no-install-recommends --no-install-suggests install apt-utils ca-certificates && \
+  echo ">>> Some more dependencies (because eosio.cdt/build.sh doesn't support noninteractive mode) ..." && \
+  apt-get -V -y --no-install-recommends --no-install-suggests install \
+    git \
+    \
+    clang-4.0 lldb-4.0 libclang-4.0-dev cmake make automake libbz2-dev libssl-dev \
+    libgmp3-dev autotools-dev build-essential libicu-dev python2.7-dev python3-dev \
+    autoconf libtool curl zlib1g-dev doxygen graphviz && \
+  \
+  echo ">>> Cloning git repository ... " && \
+  echo ">>> INFO:" && \
+  echo " * tarball https://github.com/EOSIO/eosio.cdt/archive/v1.6.3.tar.gz doesn't contain" && \
+  echo "   submodule sources (e.g. eosio_llvm), so may not be used for building CDT" && \
+  echo " * shallow copying allows to reduce the amount of cloned data" && \
+  git clone --recurse-submodules -b v1.6.3 --shallow-since=2019-01-01 https://github.com/EOSIO/eosio.cdt.git && \
+  \
+  cd eosio.cdt/ && \
+  \
+  echo ">>> Applying patch for single-thread compiling ..." && \
+  patch -p1 -d eosio_llvm/tools/lld/ -i /${cdt_linker_patch} && \
+  echo "Applying patch to allow seting build threads number from the outside ..." && \
+  patch -p0 -i /${cdt_threads_patch} && \
+  \
+  echo ">>> Compiling ..." && \
+  env CORES=${nproc} ./build.sh && \
+  \
+  echo ">>> Generating deb package and moving it to / ..." && \
+  cd build/packages/ && bash -x ./generate_package.sh deb && mv eosio.cdt_1.6.3-1_amd64.deb / && \
+  \
+  echo ">>> Cleaning ..." && \
+  cd / && rm -rf eosio.cdt ${cdt_threads_patch} ${cdt_linker_patch}

--- a/cicd/eosio.cdt-allow-set-make-threads.patch
+++ b/cicd/eosio.cdt-allow-set-make-threads.patch
@@ -1,0 +1,19 @@
+--- build.sh.orig	2019-12-11 21:03:30.371359494 +0300
++++ build.sh	2019-12-11 21:05:08.891353621 +0300
+@@ -75,10 +75,12 @@
+    FREE_MEM=`LC_ALL=C free | grep "Mem:" | awk '{print $4}'`
+ fi
+ 
+-CORES_AVAIL=`getconf _NPROCESSORS_ONLN`
+-MEM_CORES=$(( ${FREE_MEM}/4000000 )) # 4 gigabytes per core
+-MEM_CORES=$(( $MEM_CORES > 0 ? $MEM_CORES : 1 ))
+-CORES=$(( $CORES_AVAIL < $MEM_CORES ? $CORES_AVAIL : $MEM_CORES ))
++if [[ -z "$CORES" ]]; then
++   CORES_AVAIL=`getconf _NPROCESSORS_ONLN`
++   MEM_CORES=$(( ${FREE_MEM}/4000000 )) # 4 gigabytes per core
++   MEM_CORES=$(( $MEM_CORES > 0 ? $MEM_CORES : 1 ))
++   CORES=$(( $CORES_AVAIL < $MEM_CORES ? $CORES_AVAIL : $MEM_CORES ))
++fi
+ 
+ #check submodules
+ if [ $(( $(git submodule status --recursive | grep -c "^[+\-]") )) -gt 0 ]; then


### PR DESCRIPTION
```
$ docker build -t patched-cdt:latest --build-arg nproc=8 -f cicd/Dockerfile.ubuntu.patched-cdt  .
```

Result:

```
$ docker run --rm -it patched-cdt ls -lh /
total 107M
drwxr-xr-x   2 root root 4.0K Oct 29 21:25 bin
drwxr-xr-x   2 root root 4.0K Apr 24  2018 boot
drwxr-xr-x   5 root root  360 Dec 12 11:39 dev
-rw-r--r--   1 root root 107M Dec 12 11:28 eosio.cdt_1.6.3-1_amd64.deb
drwxr-xr-x   1 root root 4.0K Dec 12 11:39 etc
drwxr-xr-x   2 root root 4.0K Apr 24  2018 home
drwxr-xr-x   1 root root 4.0K Dec 12 11:00 lib
drwxr-xr-x   2 root root 4.0K Oct 29 21:25 lib64
drwxr-xr-x   2 root root 4.0K Oct 29 21:25 media
drwxr-xr-x   2 root root 4.0K Oct 29 21:25 mnt
drwxr-xr-x   2 root root 4.0K Oct 29 21:25 opt
dr-xr-xr-x 394 root root    0 Dec 12 11:39 proc
drwx------   2 root root 4.0K Oct 29 21:25 root
drwxr-xr-x   1 root root 4.0K Oct 31 22:20 run
drwxr-xr-x   1 root root 4.0K Oct 31 22:20 sbin
drwxr-xr-x   2 root root 4.0K Oct 29 21:25 srv
dr-xr-xr-x  12 root root    0 Dec 12 11:39 sys
drwxrwxrwt   1 root root 4.0K Dec 12 11:28 tmp
drwxr-xr-x   1 root root 4.0K Oct 29 21:25 usr
drwxr-xr-x   1 root root 4.0K Oct 29 21:25 var
```