### PR TITLE
make atomic _need_notify variable

### DIFF
--- a/plugins/randpa_plugin/include/eosio/randpa_plugin/randpa.hpp
+++ b/plugins/randpa_plugin/include/eosio/randpa_plugin/randpa.hpp
@@ -119,7 +119,7 @@ public:
 
 private:
     std::mutex _message_queue_mutex;
-    bool _need_notify = true;
+    std::atomic<bool> _need_notify { true };
     std::condition_variable _new_msg_cond;
     std::queue<message_ptr> _message_queue;
     std::atomic<bool> _done { false };


### PR DESCRIPTION
fix possible data race when read/write `_need_notify` variable in randpa message queue