### PR TITLE
CYB-518 Fix simulator for full nodes.

### DIFF
--- a/simulator/include/randpa.hpp
+++ b/simulator/include/randpa.hpp
@@ -15,16 +15,12 @@ using namespace randpa_finality;
 
 using randpa_ptr = std::unique_ptr<randpa>;
 
-static signature_provider_type make_key_signature_provider(const private_key_type& key) {
-   return [key]( const digest_type& digest ) {
-      return key.sign(digest);
-   };
-}
+//---------- types ----------//
 
 class RandpaNode: public Node {
 public:
-    explicit RandpaNode(int id, Network && net, fork_db && db_, private_key_type private_key):
-        Node(id, std::move(net), std::move(db_), std::move(private_key))
+    explicit RandpaNode(uint32_t id, node_type type, Network && net, fork_db && db_, private_key_type private_key)
+        : Node{id, type, std::move(net), std::move(db_), std::move(private_key)}
     {
         init();
         tree_node_unique_ptr root = std::make_unique<tree_node>(tree_node { db.last_irreversible_block_id() });;
@@ -35,20 +31,6 @@ public:
     void init() {
         init_channels();
         init_randpa();
-    }
-
-    virtual void restart() override {
-        logger << "[Node] #" << id << " restarted " << std::endl;
-        init();
-        randpa_impl->start(copy_fork_db());
-        auto runner = get_runner();
-        auto from = this->id;
-        for (uint32_t to = 0; to < runner->get_instances(); to++) {
-            int delay = runner->get_delay_matrix()[from][to];
-            if (from != to && delay != -1) {
-                on_new_peer_event(to);
-            }
-        }
     }
 
     prefix_tree_ptr copy_fork_db() {
@@ -75,7 +57,7 @@ public:
     }
 
     void on_receive(uint32_t from, void* msg) override {
-        logger << "[Node] #" << this->id << " on_receive " << std::endl;
+        logger << "[Node] #" << id << " on_receive " << std::endl;
         auto data = *static_cast<randpa_net_msg*>(msg);
         data.ses_id = from;
         data.receive_time = fc::time_point::now();
@@ -88,15 +70,29 @@ public:
     }
 
     void on_accepted_block_event(pair<block_id_type, public_key_type> block) override {
-        logger << "[Node] #" << this->id << " on_accepted_block_event " << std::endl;
+        logger << "[Node] #" << id << " on_accepted_block_event " << std::endl;
         ev_ch->send(randpa_event { ::on_accepted_block_event { block.first, db.fetch_prev_block_id(block.first),
                                                                 block.second, get_active_bp_keys()
                                                                 } });
     }
 
     void on_irreversible_block_event(const block_id_type& block) override {
-        logger << "[Node] #" << this->id << " on_irreversible_event " << std::endl;
+        logger << "[Node] #" << id << " on_irreversible_event " << std::endl;
         ev_ch->send(randpa_event { ::on_irreversible_event { block } });
+    }
+
+    void restart() override {
+        logger << "[Node] #" << id << " restarted " << std::endl;
+        init();
+        randpa_impl->start(copy_fork_db());
+        auto runner = get_runner();
+        auto from = id;
+        for (uint32_t to = 0; to < runner->get_instances(); to++) {
+            int delay = runner->get_delay_matrix()[from][to];
+            if (from != to && delay != -1) {
+                on_new_peer_event(to);
+            }
+        }
     }
 
     randpa& get_randpa() const {
@@ -125,8 +121,20 @@ private:
             .set_event_channel(ev_ch)
             .set_in_net_channel(in_net_ch)
             .set_out_net_channel(out_net_ch)
-            .set_finality_channel(finality_ch)
-            .set_signature_providers({make_key_signature_provider(private_key)}, {private_key.get_public_key()});
+            .set_finality_channel(finality_ch);
+        if (type == node_type::BP) {
+            logger << "[Node] #" << id << ": setting explicit signature provider for BP; "
+                << private_key.get_public_key() << std::endl;
+            randpa_impl->set_signature_providers({ make_key_signature_provider(private_key) },
+                                                 { private_key.get_public_key() }
+            );
+        }
+    }
+
+    static signature_provider_type make_key_signature_provider(const private_key_type& key) {
+        return [key](const digest_type& digest) {
+            return key.sign(digest);
+        };
     }
 
     net_channel_ptr in_net_ch;
@@ -136,4 +144,3 @@ private:
 
     randpa_ptr randpa_impl;
 };
-

--- a/simulator/main.cpp
+++ b/simulator/main.cpp
@@ -1,13 +1,24 @@
-#include <gtest/gtest.h>
 #include "log.hpp"
+
 #include <fc/log/logger.hpp>
+#include <fc/log/logger_config.hpp>
+
+#include <gtest/gtest.h>
 
 using namespace std;
+
+void init_randpa_logger() {
+    auto cfg = fc::logging_config::default_config();
+    cfg.loggers.push_back(cfg.loggers[0]);
+    cfg.loggers.back().name = "randpa_plugin";
+    fc::log_config::configure_logging(cfg);
+}
 
 int main(int argc, char **argv) {
     auto seed = time(NULL);
     std::srand(seed);
     std::cout << "Random number generator seeded to " << seed << std::endl;
+    init_randpa_logger();
 
     bool is_verbose = false;
     std::string verbose_arg = "--verbose";
@@ -18,7 +29,9 @@ int main(int argc, char **argv) {
        }
     }
 
-    if (!is_verbose) {
+    if (is_verbose) {
+        fc::logger::get().set_log_level(fc::log_level::debug);
+    } else {
         std::cout << "Logging disabled, use --verbose to enable" << std::endl;
         logger.enabled(false);
         fc::logger::get().set_log_level(fc::log_level::off);

--- a/simulator/tests/randpa_finality_tests.cpp
+++ b/simulator/tests/randpa_finality_tests.cpp
@@ -1,35 +1,37 @@
+#include "randpa.hpp"
+#include "simulator.hpp"
+
 #include <gtest/gtest.h>
 
-#include <string>
-#include <iostream>
-
-#include <simulator.hpp>
 #include <cstdlib>
 #include <ctime>
+#include <iostream>
 #include <random>
-#include <randpa.hpp>
+#include <string>
 
 using namespace std;
 
-using std::string;
-
-
 TEST(randpa_finality, fullnodes_over_fullnodes) {
+    //                        +-- 3[b] -- 5[f] -- 6[f]
+    //                        |    |
+    // 0[f] -- 1[f] -- 2[b] --+    |
+    //                        |    |
+    //                        +-- 4[b] -- 7[f] -- 8[f]
     auto runner = TestRunner(9);
-    vector<node_type> nodetypes {   node_type::FN, node_type::FN, node_type::BP,
-                                    node_type::BP, node_type::BP, node_type::FN,
-                                    node_type::FN, node_type::FN, node_type::FN};
+    vector<node_type> nodetypes { node_type::FN, node_type::FN, node_type::BP,
+                                  node_type::BP, node_type::BP, node_type::FN,
+                                  node_type::FN, node_type::FN, node_type::FN };
     runner.load_nodetypes(nodetypes);
     graph_type g;
-    g.push_back({{1, 10}});
-    g.push_back({{2, 10}});
-    g.push_back({{3, 20}, {4, 20}});
-    g.push_back({{4, 20}, {5, 30}});
-    g.push_back({{7, 10}});
-    g.push_back({{6, 30}});
-    g.push_back({{}});
-    g.push_back({{8, 10}});
-    g.push_back({{}});
+    /* 0 */g.push_back({{1, 10}});
+    /* 1 */g.push_back({{2, 10}});
+    /* 2 */g.push_back({{3, 20}, {4, 20}});
+    /* 3 */g.push_back({{4, 20}, {5, 30}});
+    /* 4 */g.push_back({{7, 10}});
+    /* 5 */g.push_back({{6, 30}});
+    /* 6 */g.push_back({{}});
+    /* 7 */g.push_back({{8, 10}});
+    /* 8 */g.push_back({{}});
     runner.load_graph(g);
     runner.add_stop_task(8 * runner.get_slot_ms());
     runner.run<RandpaNode>();
@@ -94,7 +96,7 @@ TEST(randpa_finality, fullnodes_over_round_ring) {
     auto random = [&](){ return (rand() % (max_delay - min_delay)) + min_delay; };
 
     graph_type g;
-    vector<pair<int, int> > empty_vector;
+    vector<pair<int, int>> empty_vector;
     g.push_back({{1, 10}});
     g.push_back({{2, 20}});
     g.push_back({{3, 10}});
@@ -132,7 +134,7 @@ TEST(randpa_finality, fullnodes_over_smash_ring) {
     auto random = [&](){ return (rand() % (max_delay - min_delay)) + min_delay; };
 
     graph_type g;
-    vector<pair<int, int> > empty_vector;
+    vector<pair<int, int>> empty_vector;
     g.push_back({{1, 10}});
     g.push_back({{2, 20}});
     g.push_back({{3, 10}});
@@ -173,7 +175,7 @@ TEST(randpa_finality, bp_over_six_fn) {
     auto random = [&](){ return (rand() % (max_delay - min_delay)) + min_delay; };
 
     graph_type g;
-    vector<pair<int, int> > empty_vector;
+    vector<pair<int, int>> empty_vector;
     g.push_back({{1, random()}, {2, random()}, {3, random()}});
     for (auto i = 0; i < 3; ++i) {
         g.push_back({{4, random()}, {5, random()}, {6, random()}});
@@ -206,7 +208,7 @@ TEST(randpa_finality, bp_over_spider_net_fn) {
     auto random = [&](){ return (rand() % (max_delay - min_delay)) + min_delay; };
 
     graph_type g(nodes_amount);
-    vector<pair<int, int> > empty_vector;
+    vector<pair<int, int>> empty_vector;
     g[0] = {{1, random()}};
     g[1] = {{2, random()}, {9, random()}};
     g[2] = {{3, random()}, {4, random()}};
@@ -309,7 +311,7 @@ TEST(randpa_finality, bp_over_horizontal_lines_fn) {
 
 TEST(randpa_finality, three_nodes) {
     auto runner = TestRunner(3);
-    vector<pair<int, int> > v0{{1, 2}, {2, 10}};
+    vector<pair<int, int>> v0{{1, 2}, {2, 10}};
     graph_type g;
     g.push_back(v0);
     runner.load_graph(g);
@@ -322,7 +324,7 @@ TEST(randpa_finality, three_nodes) {
 
 TEST(randpa_finality, three_nodes_large_roundtrip) {
     auto runner = TestRunner(3);
-    vector<pair<int, int> > v0{{1, 2}};
+    vector<pair<int, int>> v0{{1, 2}};
     graph_type g;
     g.push_back(v0);
     runner.load_graph(g);
@@ -337,10 +339,10 @@ TEST(randpa_finality, three_nodes_large_roundtrip) {
 TEST(randpa_finality, many_nodes) {
     size_t nodes_amount = 21;
     auto runner = TestRunner(nodes_amount);
-    vector<pair<int, int> > v0{{1, 20}, {2, 10}, {3, 10}, {4, 30}, {5, 30}};
-    vector<pair<int, int> > v5{{6, 10}, {7, 30}, {8, 20}, {9, 10}, {10, 30}};
-    vector<pair<int, int> > v10{{11, 10}, {12, 10}, {13, 10}, {14, 10}, {15, 30}};
-    vector<pair<int, int> > v15{{16, 10}, {17, 10}, {18, 10}, {19, 10}, {20, 30}};
+    vector<pair<int, int>> v0{{1, 20}, {2, 10}, {3, 10}, {4, 30}, {5, 30}};
+    vector<pair<int, int>> v5{{6, 10}, {7, 30}, {8, 20}, {9, 10}, {10, 30}};
+    vector<pair<int, int>> v10{{11, 10}, {12, 10}, {13, 10}, {14, 10}, {15, 30}};
+    vector<pair<int, int>> v15{{16, 10}, {17, 10}, {18, 10}, {19, 10}, {20, 30}};
     graph_type g(nodes_amount);
     g[0] = v0;
     g[5] = v5;
@@ -357,7 +359,7 @@ TEST(randpa_finality, many_nodes) {
 
 TEST(randpa_finality, finalize_long_chain) {
     auto runner = TestRunner(3);
-    vector<pair<int, int> > v0{{1, 2}};
+    vector<pair<int, int>> v0{{1, 2}};
     graph_type g;
     g.push_back(v0);
     runner.load_graph(g);
@@ -386,7 +388,7 @@ TEST(randpa_finality, random_delays) {
 
     graph_type g;
     for (auto i = 0; i < nodes_cnt; i++) {
-        vector<pair<int, int> > pairs;
+        vector<pair<int, int>> pairs;
         for (auto j = i + 1; j < nodes_cnt; j++) {
             pairs.push_back({ j, random() });
         }
@@ -480,12 +482,12 @@ TEST(randpa_finality, randpa_disabled_nodes) {
             runner.add_node<Node>(big_conf_number);
         }
     }
-    
-    vector<pair<int, int> > v0{{1, 2}, {2, 10}};
+
+    vector<pair<int, int>> v0{{1, 2}, {2, 10}};
     graph_type g;
     g.push_back(v0);
     runner.load_graph(g);
-    
+
     // dpos finality fails and randpa frozen
     const int32_t _max_finality_lag_blocks = 69 * 12 * 2 * 2;
     runner.add_stop_task((_max_finality_lag_blocks + 1) * runner.get_slot_ms());
@@ -497,17 +499,17 @@ TEST(randpa_finality, randpa_disabled_nodes) {
             if (node_ptr) {
                 EXPECT_EQ(frozen, node_ptr->get_randpa().is_frozen());
             }
-        }    
+        }
     };
 
     check_randpa_frozen(true);
-    
-    // change conf_number to dpos_threshold 
+
+    // change conf_number to dpos_threshold
     for (int i = 0; i < nodes_amount; i++) {
         const auto node_ptr = runner.get_node(i);
         node_ptr->db.set_conf_number(dpos_threshold);
     }
-    
+
     runner.add_stop_task(4000 * runner.get_slot_ms());
     runner.run_loop();
     // dpos finality should be back and randpa active


### PR DESCRIPTION
Added node type information in `Node` and `RandpaNode` classes to choose, whether to call `set_signature_providers()`, or not.

Without #45 applied:
```
[----------] Global test environment tear-down
[==========] 23 tests from 2 test cases ran. (24211 ms total)
[  PASSED  ] 15 tests.
[  FAILED  ] 8 tests, listed below:
[  FAILED  ] randpa_finality.fullnodes_over_fullnodes
[  FAILED  ] randpa_finality.fullnodes_over_five_fullnodes
[  FAILED  ] randpa_finality.fullnodes_over_round_ring
[  FAILED  ] randpa_finality.fullnodes_over_smash_ring
[  FAILED  ] randpa_finality.bp_over_six_fn
[  FAILED  ] randpa_finality.bp_over_spider_net_fn
[  FAILED  ] randpa_finality.bp_over_vertical_lines_fn
[  FAILED  ] randpa_finality.bp_over_horizontal_lines_fn

 8 FAILED TESTS
```

With #45 applied:
```
[----------] Global test environment tear-down
[==========] 23 tests from 2 test cases ran. (38443 ms total)
[  PASSED  ] 23 tests.
```